### PR TITLE
Use UTC timestamp for teams in different timezones [fixes #14]

### DIFF
--- a/lib/capistrano/deploy_tags.rb
+++ b/lib/capistrano/deploy_tags.rb
@@ -6,7 +6,7 @@ module Capistrano
     end
 
     def git_tag_for(stage)
-      "#{stage}-#{Time.now.strftime("%Y.%m.%d-%H%M%S")}"
+      "#{stage}-#{Time.new.utc.strftime('%Y.%m.%d-%H%M%S')}"
     end
 
     def safe_run(*args)


### PR DESCRIPTION
Addresses https://github.com/mydrive/capistrano-deploytags/issues/14
