### PR TITLE
correctly handle failing git fetch

### DIFF
--- a/lib/capistrano/deploy_tags.rb
+++ b/lib/capistrano/deploy_tags.rb
@@ -2,7 +2,12 @@ module Capistrano
   module DeployTags
     def pending_git_changes?
       # Do we have any changes vs HEAD on deployment branch?
-      !(`git fetch && git diff #{branch} --shortstat`.strip.empty?)
+      out = `git fetch 2>&1`
+      if $?.success?
+        ! (`git diff #{branch} --shortstat`.strip.empty?)
+      else
+        raise CommandError.new("git fetch failed:\n" + out)
+      end
     end
 
     def git_tag_for(stage)


### PR DESCRIPTION
If the repository doesn't have an upstream branch configured, git fetch will
output an error; handle this separately to prevent it interfering with the git
diff call which checks to see if we have any pending changes.
