### PR TITLE
Add a :deploytag_suffix setting.

### DIFF
--- a/lib/capistrano/deploy_tags.rb
+++ b/lib/capistrano/deploy_tags.rb
@@ -75,7 +75,8 @@ module Capistrano
             logger.log Capistrano::Logger::INFO, "Tagging #{current_sha} for deployment"
 
             tag_user = (ENV['USER'] || ENV['USERNAME']).strip
-            cdt.safe_run 'git', 'tag', '-a', cdt.git_tag_for(stage), '-m', "#{tag_user} deployed #{current_sha} to #{stage}"
+            suffix = fetch(:deploytag_suffix, '')
+            cdt.safe_run 'git', 'tag', '-a', cdt.git_tag_for(stage), '-m', "#{tag_user} deployed #{current_sha} to #{stage} #{suffix}".strip
             cdt.safe_run 'git', 'push', '--tags' if cdt.has_remote?
           end
         end

--- a/spec/capistrano_deploy_tags_spec.rb
+++ b/spec/capistrano_deploy_tags_spec.rb
@@ -116,6 +116,17 @@ describe Capistrano::DeployTags do
       end
     end
 
+    it "respects deploytag_suffix setting" do
+      with_clean_repo do
+        configuration.set(:deploytag_suffix, ' [ci skip]')
+        configuration.find_and_execute_task('git:tagdeploy')
+
+        tags = `git tag -l -n1`.split(/\n/)
+        tags.should have(1).items
+        tags.first.should =~ /\[ci skip\]/
+      end
+    end
+
     it "does not run when :no_deploytags is defined by (i.e. by the stage)" do
       with_clean_repo do
         configuration.set(:branch, 'master')


### PR DESCRIPTION
This setting appends user-specified string to tag annotation. It can
be useful e.g. with Travis CI, which currently rebuilds all pushed
tags and doesn't have a way to turn it off.
