### PR TITLE
Make UTC optional

### DIFF
--- a/lib/capistrano/deploytags.rb
+++ b/lib/capistrano/deploytags.rb
@@ -11,7 +11,13 @@ module CapistranoDeploytags
     end
 
     def self.formatted_time
-      Time.new.utc.strftime(fetch(:deploytag_time_format, "%Y.%m.%d-%H%M%S-utc"))
+      now = if fetch(:deploytag_utc, true)
+        Time.now.utc
+      else
+        Time.now
+      end
+
+      now.strftime(fetch(:deploytag_time_format, "%Y.%m.%d-%H%M%S-#{now.zone.downcase}"))
     end
 
     def self.commit_message(current_sha, stage)


### PR DESCRIPTION
We have a team that's based entirely in a single timezone, so using UTC for the deploy tags just makes things more confusing for us.

This PR adds an option to opt for local time timestamps instead of UTC (and changes the default time format to include the relevant timezone).
